### PR TITLE
chore: update Hugo version in theme.toml

### DIFF
--- a/theme.toml
+++ b/theme.toml
@@ -20,7 +20,7 @@ features = [
     "search",
 ]
 
-min_version = "0.87.0"
+min_version = "0.100.2"
 
 [author]
 name = "Jimmy Cai"


### PR DESCRIPTION
continue is not supported by old versions